### PR TITLE
New single series trend line color

### DIFF
--- a/scoreboard-colors.scss
+++ b/scoreboard-colors.scss
@@ -176,7 +176,7 @@ $score-colors:
 // $score-infantry-blue-text-background: #DDE4ED;
 
 // Chart series colors
-$chart-series-default:                  rgba($color-true-black,0.18); // Only used for single-series line charts and trendlines
+$chart-series-default:                  rgba($color-true-black, 0.3); // Only used for single-series line charts and trendlines
 
 $chart-series-red-dark:                 #C93C20;
 $chart-series-red-medium:               $score-red;


### PR DESCRIPTION
This is ultimately for https://github.com/SpiderStrategies/Scoreboard/issues/24277

@nathanbowser, the `scoreboard-chart` project uses this color so `scoreboard-colors` will have to be bumped there. Then, `scorboard-chart` will need to be bumped in SB3 (`release-3.3`) to bring the updated color there.