### PR TITLE
Squash warnings from newer sass

### DIFF
--- a/scoreboard-colors.scss
+++ b/scoreboard-colors.scss
@@ -377,14 +377,14 @@ $color-tree-editable-highlight: $color-gold;
 // Mixins to help iterate over the two color arrays
 @mixin standard-fill($color-list)  {
   @each $color in $color-list {
-    &.#{nth($color, 1)} {
+    &.#{"" + nth($color, 1)} { // Concat a string to squash sass warnings
       fill: nth($color, 2);
     }
   }
 }
 @mixin standard-stroke($color-list)  {
   @each $color in $color-list {
-    &.#{nth($color, 1)} {
+    &.#{"" + nth($color, 1)} { // Concat a string to squash sass warnings
       stroke: nth($color, 2);
     }
   }
@@ -392,7 +392,7 @@ $color-tree-editable-highlight: $color-gold;
 
 @mixin lighter-fill-darker-stroke($color-list)  {
   @each $color in $color-list {
-    &.#{nth($color, 1)} {
+    &.#{"" + nth($color, 1)} { // Concat a string to squash sass warnings
       stroke: mix($color-true-black, nth($color, 2), 12%);
       fill: mix($color-white, nth($color, 2), 30%);
     }


### PR DESCRIPTION
```
Warning: You probably don't mean to use the color value orange in interpolation here.
It may end up represented as orange, which will likely produce invalid CSS.
Always quote color names when using them as strings or map keys (for example, "orange").
If you really want to use the color value here, use '"" + nth($color, 1)'.
```