### PR TITLE
#65303 Caches colors to speed up shape widget rendering

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,45 +3,12 @@ const BLACK = [0, 0, 0, 1]
 
 // Cache for CSS color values to avoid repeated getComputedStyle calls
 let colorCache = new Map()
-let isCacheInitialized = false
-
-// Known palette colors that can be cached
-const PALETTE_COLORS = [
-  'white', 'slate', 'infantry-blue',
-  'red-dark', 'red-medium', 'red-light',
-  'orange-dark', 'orange-medium', 'orange-light',
-  'yellow-dark', 'yellow-medium', 'yellow-light',
-  'green-dark', 'green-medium', 'green-light',
-  'turquoise-dark', 'turquoise-medium', 'turquoise-light',
-  'blue-dark', 'blue-medium', 'blue-light',
-  'periwinkle-dark', 'periwinkle-medium', 'periwinkle-light',
-  'purple-dark', 'purple-medium', 'purple-light',
-  'fuchsia-dark', 'fuchsia-medium', 'fuchsia-light',
-  'gray-darker', 'gray-dark', 'gray-medium', 'gray-light'
-]
 
 /**
- * Initialize the color cache by reading all palette colors once
- */
-const initializeColorCache = () => {
-  const computedStyle = window.getComputedStyle(document.body)
-
-  PALETTE_COLORS.forEach(color => {
-    const cssValue = computedStyle.getPropertyValue(`--palette-color-${color}`).trim()
-    if (cssValue) {
-      colorCache.set(color, cssValue)
-    }
-  })
-
-  isCacheInitialized = true
-}
-
-/**
- * Clear the color cache and force re-initialization
+ * Clear the color cache
  */
 const clearColorCache = () => {
   colorCache.clear()
-  isCacheInitialized = false
 }
 
 /*
@@ -111,14 +78,12 @@ const getColor = color => {
  * Receives a named palette color and returns the color object from `getColor`
  */
 export const lookup = color => {
-  if (!isCacheInitialized) {
-    initializeColorCache()
+  if (!colorCache.has(color)) {
+    const value = window.getComputedStyle(document.body).getPropertyValue(`--palette-color-${color}`).trim()
+    colorCache.set(color, value || '')
   }
 
-  const cachedColor = colorCache.get(color) ||
-    window.getComputedStyle(document.body).getPropertyValue(`--palette-color-${color}`).trim()
-
-  return getColor(cachedColor)
+  return getColor(colorCache.get(color))
 }
 
 /*

--- a/index.js
+++ b/index.js
@@ -4,13 +4,6 @@ const BLACK = [0, 0, 0, 1]
 // Cache for CSS color values to avoid repeated getComputedStyle calls
 let colorCache = new Map()
 
-/**
- * Clear the color cache
- */
-const clearColorCache = () => {
-  colorCache.clear()
-}
-
 /*
  * Receives an array of the rgb, returns a hex value
  */
@@ -187,7 +180,6 @@ export {
   adjustLightness,
   changeColor,
   mix,
-  clearColorCache,
   BLACK,
   WHITE
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,49 @@
 const WHITE = [255, 255, 255, 1]
 const BLACK = [0, 0, 0, 1]
 
+// Cache for CSS color values to avoid repeated getComputedStyle calls
+let colorCache = new Map()
+let isCacheInitialized = false
+
+// Known palette colors that can be cached
+const PALETTE_COLORS = [
+  'white', 'slate', 'infantry-blue',
+  'red-dark', 'red-medium', 'red-light',
+  'orange-dark', 'orange-medium', 'orange-light',
+  'yellow-dark', 'yellow-medium', 'yellow-light',
+  'green-dark', 'green-medium', 'green-light',
+  'turquoise-dark', 'turquoise-medium', 'turquoise-light',
+  'blue-dark', 'blue-medium', 'blue-light',
+  'periwinkle-dark', 'periwinkle-medium', 'periwinkle-light',
+  'purple-dark', 'purple-medium', 'purple-light',
+  'fuchsia-dark', 'fuchsia-medium', 'fuchsia-light',
+  'gray-darker', 'gray-dark', 'gray-medium', 'gray-light'
+]
+
+/**
+ * Initialize the color cache by reading all palette colors once
+ */
+const initializeColorCache = () => {
+  const computedStyle = window.getComputedStyle(document.body)
+
+  PALETTE_COLORS.forEach(color => {
+    const cssValue = computedStyle.getPropertyValue(`--palette-color-${color}`).trim()
+    if (cssValue) {
+      colorCache.set(color, cssValue)
+    }
+  })
+
+  isCacheInitialized = true
+}
+
+/**
+ * Clear the color cache and force re-initialization
+ */
+const clearColorCache = () => {
+  colorCache.clear()
+  isCacheInitialized = false
+}
+
 /*
  * Receives an array of the rgb, returns a hex value
  */
@@ -68,7 +111,14 @@ const getColor = color => {
  * Receives a named palette color and returns the color object from `getColor`
  */
 export const lookup = color => {
-  return getColor(window.getComputedStyle(document.body).getPropertyValue(`--palette-color-${color}`))
+  if (!isCacheInitialized) {
+    initializeColorCache()
+  }
+
+  const cachedColor = colorCache.get(color) ||
+    window.getComputedStyle(document.body).getPropertyValue(`--palette-color-${color}`)
+
+  return getColor(cachedColor)
 }
 
 /*
@@ -172,6 +222,7 @@ export {
   adjustLightness,
   changeColor,
   mix,
+  clearColorCache,
   BLACK,
   WHITE
 }

--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ export const lookup = color => {
   }
 
   const cachedColor = colorCache.get(color) ||
-    window.getComputedStyle(document.body).getPropertyValue(`--palette-color-${color}`)
+    window.getComputedStyle(document.body).getPropertyValue(`--palette-color-${color}`).trim()
 
   return getColor(cachedColor)
 }

--- a/index.js
+++ b/index.js
@@ -1,8 +1,19 @@
 const WHITE = [255, 255, 255, 1]
 const BLACK = [0, 0, 0, 1]
 
-// Cache for CSS color values to avoid repeated getComputedStyle calls
-let colorCache = new Map()
+// Cache for CSS variable values to avoid repeated getComputedStyle calls
+let cssVariableCache = new Map()
+
+/**
+ * Get a CSS variable value with caching
+ */
+const getCSSVariable = (cssVar) => {
+  if (!cssVariableCache.has(cssVar)) {
+    const value = window.getComputedStyle(document.body).getPropertyValue(cssVar).trim()
+    cssVariableCache.set(cssVar, value || '')
+  }
+  return cssVariableCache.get(cssVar)
+}
 
 /*
  * Receives an array of the rgb, returns a hex value
@@ -71,12 +82,8 @@ const getColor = color => {
  * Receives a named palette color and returns the color object from `getColor`
  */
 export const lookup = color => {
-  if (!colorCache.has(color)) {
-    const value = window.getComputedStyle(document.body).getPropertyValue(`--palette-color-${color}`).trim()
-    colorCache.set(color, value || '')
-  }
-
-  return getColor(colorCache.get(color))
+  const cssValue = getCSSVariable(`--palette-color-${color}`)
+  return getColor(cssValue)
 }
 
 /*
@@ -180,6 +187,7 @@ export {
   adjustLightness,
   changeColor,
   mix,
+  getCSSVariable,
   BLACK,
   WHITE
 }

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ let cssVariableCache = new Map()
 /**
  * Get a CSS variable value with caching
  */
-const getCSSVariable = (cssVar) => {
+function getCSSVariable(cssVar) {
   if (!cssVariableCache.has(cssVar)) {
     const value = window.getComputedStyle(document.body).getPropertyValue(cssVar).trim()
     cssVariableCache.set(cssVar, value || '')

--- a/test.js
+++ b/test.js
@@ -684,7 +684,8 @@ test('color conversions', t => {
 test('getCSSVariable caching', t => {
   let callCount = 0
 
-  globalThis.window = {
+  // Mock browser globals for Node.js testing environment
+  global.window = {
     getComputedStyle: () => ({
       getPropertyValue: (prop) => {
         callCount++
@@ -692,7 +693,7 @@ test('getCSSVariable caching', t => {
       }
     })
   }
-  globalThis.document = { body: {} }
+  global.document = { body: {} }
 
   assert.equal(getCSSVariable('--test-var'), '#123456')
   assert.equal(callCount, 1)

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 import {test} from 'node:test'
 import * as assert from 'node:assert/strict'
-import {rgbToHex, hexToRgba, changeColor, adjustLightness, getTextVariation} from './index.js'
+import {rgbToHex, hexToRgba, changeColor, adjustLightness, getTextVariation, getCSSVariable} from './index.js'
 
 // In the future, this test is going to look obnoxious, but
 // it was created when we migrated adjustLightness from sass to
@@ -679,5 +679,25 @@ test('color conversions', t => {
   let color = '#c93c20'
   assert.deepEqual(hexToRgba(color), [ 201, 60, 32, 1 ])
   assert.equal(rgbToHex([ 201, 60, 32, 1 ]), color)
+})
+
+test('getCSSVariable caching', t => {
+  let callCount = 0
+
+  globalThis.window = {
+    getComputedStyle: () => ({
+      getPropertyValue: (prop) => {
+        callCount++
+        return prop === '--test-var' ? '#123456' : ''
+      }
+    })
+  }
+  globalThis.document = { body: {} }
+
+  assert.equal(getCSSVariable('--test-var'), '#123456')
+  assert.equal(callCount, 1)
+
+  assert.equal(getCSSVariable('--test-var'), '#123456')
+  assert.equal(callCount, 1)
 })
 


### PR DESCRIPTION
Caches colors to speed up performance, see [this](https://github.com/SpiderStrategies/Scoreboard/issues/65303) issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced performance of color lookups by caching CSS palette colors to reduce repeated style queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->